### PR TITLE
fix: prod url

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,6 +16,6 @@ module.exports = {
     };
   },
   publicRuntimeConfig: {
-    appUrl: isProd ? "https://incubateur.social.gouv.fr/emjpm-portail" : "http://localhost:3000"
+    appUrl: isProd ? "http://socialgouv.github.io/emjpm-portail" : "http://localhost:3000"
   }
 };


### PR DESCRIPTION
Following website migration previous url is a 404.
temporary fix with the GH deployment url